### PR TITLE
allow for a special middle button and allow for custom styling of that button

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -3,6 +3,7 @@ import Expo from 'expo';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { createStackNavigator } from 'react-navigation';
 import BottomTabs from './src/BottomTabs';
+import BottomTabsWithMiddleButton from './src/BottomTabsWithMiddleButton';
 import MaterialTopTabs from './src/MaterialTopTabs';
 
 class Home extends React.Component {
@@ -14,6 +15,14 @@ class Home extends React.Component {
           onPress={() => this.props.navigation.push('BottomTabs')}
         >
           <Text>Bottom tabs</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.item}
+          onPress={() =>
+            this.props.navigation.push('BottomTabsWithMiddleButton')
+          }
+        >
+          <Text>Bottom tabs with middle button</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.item}
@@ -34,6 +43,10 @@ const App = createStackNavigator({
   BottomTabs: {
     screen: BottomTabs,
     navigationOptions: { title: 'Bottom tabs' },
+  },
+  BottomTabsWithMiddleButton: {
+    screen: BottomTabsWithMiddleButton,
+    navigationOptions: { title: 'Bottom tabs with middle button' },
   },
   MaterialTopTabs: {
     screen: MaterialTopTabs,

--- a/example/src/BottomTabsWithMiddleButton.js
+++ b/example/src/BottomTabsWithMiddleButton.js
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { createBottomTabNavigator } from 'react-navigation-tabs';
+import { MaterialIcons } from '@expo/vector-icons';
+import PhotoGrid from './shared/PhotoGrid';
+import TouchableBounce from 'react-native/Libraries/Components/Touchable/TouchableBounce';
+
+const tabBarIcon = name => ({ tintColor }) => (
+  <MaterialIcons name={name} color={tintColor} size={24} />
+);
+
+class Album extends React.Component {
+  static navigationOptions = {
+    tabBarIcon: tabBarIcon('photo-album'),
+    tabBarButtonComponent: TouchableBounce,
+  };
+
+  render() {
+    return <PhotoGrid id="album" />;
+  }
+}
+
+class History extends React.Component {
+  static navigationOptions = {
+    tabBarIcon: tabBarIcon('history'),
+    tabBarButtonComponent: TouchableBounce,
+  };
+
+  render() {
+    return <PhotoGrid id="history" />;
+  }
+}
+
+class Cart extends React.Component {
+  static navigationOptions = {
+    tabBarIcon: tabBarIcon('shopping-cart'),
+    tabBarButtonComponent: TouchableBounce,
+  };
+
+  render() {
+    return <PhotoGrid id="cart" />;
+  }
+}
+
+export default createBottomTabNavigator(
+  {
+    Album,
+    History: {
+      screen: History,
+      navigationOptions: {
+        tabBarIcon: tabBarIcon('history'),
+        tabBarLabel: ' ',
+      },
+    },
+    Cart,
+  },
+  {
+    tabBarOptions: {
+      tabStyle: {
+        backgroundColor: '#ffe',
+      },
+      hasMiddleItem: true,
+      middleItemStyle: {
+        flex: 0,
+        width: 40,
+        backgroundColor: 'lightblue',
+      },
+    },
+  }
+);


### PR DESCRIPTION
the idea here is that I can have a custom middle plus button, that has different styling. One case is that I want it to have no flex, and just be a specific size, so that this can allow the left and right tabs take the flex space they need. Otherwise they would be sharing the whole space, and it would seem that they are more pushed to the sides that they should.
You can see this in practice if you have three tabs and have `hasMiddleItem` `false`, and `true`. When `false`, all three tabs share the space. When `true`, the left and right tabs share the space, and the middle one just takes the assigned space its given in the `middleItemStyle`.