### PR TITLE
A proposition to hide a label on a specific Tab

### DIFF
--- a/src/views/MaterialTopTabBar.js
+++ b/src/views/MaterialTopTabBar.js
@@ -10,6 +10,7 @@ export type TabBarOptions = {
   inactiveTintColor?: string,
   showLabel?: boolean,
   showIcon?: boolean,
+  tabKeyToHideLabel?: string,
   upperCaseLabel?: boolean,
   labelStyle?: any,
   iconStyle?: any,
@@ -51,12 +52,13 @@ export default class TabBarTop extends React.PureComponent<Props> {
       activeTintColor,
       inactiveTintColor,
       showLabel,
+      tabKeyToHideLabel,
       upperCaseLabel,
       labelStyle,
       allowFontScaling,
     } = this.props;
 
-    if (showLabel === false) {
+    if (showLabel === false || route.key === tabKeyToHideLabel) {
       return null;
     }
 


### PR DESCRIPTION
I needed this option .

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
I had to hide the label on a specific tab, and the only existing option hides it from all the tabs.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
example of the code I used this change on :

```js
const MainTabsNavigation = createMaterialTopTabNavigator(
    {
        Discover: DiscoverTab,
        Messages: MessagesTab,
        Notifications: NotificationsTab,
        Profile: ProfileTab
    }, {
        swipeEnabled: false,
        tabBarPosition: 'bottom',
        tabBarOptions: {
            tabKeyToHideLabel: 'Profile',
            showIcon: true,
            indicatorStyle: {
                opacity: 0
            },
            style: {
                height: 55,
                backgroundColor: Colors.primary1
            },
            labelStyle: {
                fontSize: 11
            },
            activeTintColor: Colors.secondary

        }
    } 

```

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
