### PR TITLE
feat: add additional bottom tab bar styling options

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -30,6 +30,9 @@ export type TabBarOptions = {
   showLabel: boolean,
   showIcon: boolean,
   labelStyle: any,
+  iconStyle: any,
+  activeLabelStyle: any,
+  inactiveLabelStyle: any,
   tabStyle: any,
   labelPosition?: LabelPosition,
   adaptive?: boolean,
@@ -171,6 +174,8 @@ class TabBarBottom extends React.Component<Props, State> {
       activeTintColor,
       inactiveTintColor,
       labelStyle,
+      activeLabelStyle,
+      inactiveLabelStyle,
       showLabel,
       showIcon,
       allowFontScaling,
@@ -193,6 +198,7 @@ class TabBarBottom extends React.Component<Props, State> {
             { color: tintColor },
             showIcon && horizontal ? styles.labelBeside : styles.labelBeneath,
             labelStyle,
+            focused ? activeLabelStyle : inactiveLabelStyle,
           ]}
           allowFontScaling={allowFontScaling}
         >
@@ -218,6 +224,7 @@ class TabBarBottom extends React.Component<Props, State> {
       navigation,
       activeTintColor,
       inactiveTintColor,
+      iconStyle,
       renderIcon,
       showIcon,
       showLabel,
@@ -245,6 +252,7 @@ class TabBarBottom extends React.Component<Props, State> {
           styles.iconWithExplicitHeight,
           showLabel === false && !horizontal && styles.iconWithoutLabel,
           showLabel !== false && !horizontal && styles.iconWithLabel,
+          iconStyle,
         ]}
       />
     );


### PR DESCRIPTION
### Motivation
For the UX requirements on my project, I needed to customize the size and layout of the bar and buttons. Additionally, the font needed to be different for the active/inactive labels.

While there is the option to provide a tabBarLabel or tabBarIcon, they both had limitations. The tabBarLabel diverges from the default behavior of how a title string is retrieved, I wanted to maintain that behavior. The tabBarIcon option, doesn't change the container of the icon component. Which is where I needed to adjust the margin. I could have just used a `tabBarButtonComponent`, but I would prefer to keep using the component provided by the framework to maintain existing functionality. Especially, since I just needed to adjust styles.

### Test plan
This maintains current functionality and visual design. To test this, additional styling options can be passed to the BottomTabBar via `tabOptions`, such as `activeLabelStyle` `inactiveLabelStyle`, or `iconStyle`.