### PR TITLE
Add option to specify custom active tab button style

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -31,6 +31,7 @@ export type TabBarOptions = {
   showIcon: boolean,
   labelStyle: any,
   tabStyle: any,
+  activeTabStyle?: any,
   labelPosition?: LabelPosition,
   adaptive?: boolean,
   style: any,
@@ -390,6 +391,7 @@ class TabBarBottom extends React.Component<Props, State> {
                     ? styles.tabLandscape
                     : styles.tabPortrait,
                   tabStyle,
+                  focused ? this.props.activeTabStyle : null,
                 ]}
               >
                 {this._renderIcon(scene)}


### PR DESCRIPTION
### Motivation

Right now in each tab buttons, difference between active tab button and non-active tab button is background color, tint color and opacity.

Only way to have other custom styles for active tab button (For example, highlighted top border) in current API is to create whole custom tab, which I believe it is overkill.

I think it would be easier for this simple changes to have `activeTabButtonStyle` as an option to add custom different style for active button.

### Test plan

Inject style for custom active tab and see if style changes for active tab.

For example:

```Javascript
const TabNavigator = createBottomTabNavigator(
  {
    Home: HomePage
    Calendar: CalendarPage,
    Diary: DiaryPage,
    Settings: SettingsPage
  },
  {
    showLabel: false,
    activeTabButtonStyle: {
      borderTopColor: sicklyYellow,
      borderTopWidth: 2
    }
  }
)
```

This will result to custom active style as screenshot below:

<img width="333" alt="Screen Shot 2562-07-14 at 17 15 20" src="https://user-images.githubusercontent.com/5057288/61182261-05242380-a65b-11e9-88f3-cb3837df59d8.png">



