### PR TITLE
Flow error fixes (Flow v0.92.0)

### DIFF
--- a/src/navigators/createBottomTabNavigator.js
+++ b/src/navigators/createBottomTabNavigator.js
@@ -14,7 +14,7 @@ import ResourceSavingScene from '../views/ResourceSavingScene';
 
 type Props = InjectedProps & {
   getAccessibilityRole: (props: { route: any }) => string,
-  getAccessibilityStates: (props: { route: any }) => string[],
+  getAccessibilityStates: (props: { route: any, focused: boolean }) => string[],
   lazy?: boolean,
   tabBarComponent?: React.ComponentType<*>,
   tabBarOptions?: TabBarOptions,

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -19,7 +19,7 @@ export type InjectedProps = {|
     tintColor: string,
     horizontal?: boolean,
   }) => React.Node,
-  renderScene: (props: { route: any }) => ?React.Node,
+  renderScene: (props: { route: any }) => React.Node,
   onIndexChange: (index: number) => any,
   onTabPress: (props: { route: any }) => mixed,
   onTabLongPress: (props: { route: any }) => mixed,


### PR DESCRIPTION
### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

I am using react-navigation-tabs v2.3.0 as a dependency of my React Native 0.59 project. I run Flow v0.92.0 in my project. When I run flow, it complains about two things in react-navigation-tabs, which I fix in this PR. See the full error logs for these two issues below.

I suspect these issues are not picked up by this project's own Flow check, because it uses an older version of Flow (0.78.0), but I have not tested this.

#### Property focused is missing in object type [1].
`getAccessibilityStates` in the default props of TabNavigationView accesses a field `focused`, but this does exist in the Flow type of `getAccessibilityStates` above. I added this boolean to the type.

I wondered if `focused` should be optional, but the only invocation of this function I found was in BottomTabBar.js, and it sends in focused, so I guess it can be mandatory?

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-navigation-tabs/src/navigators/createBottomTabNavigator.js:31:32

Property focused is missing in object type [1].

 [1] 17│   getAccessibilityStates: (props: { route: any }) => string[],
       :
     28│   static defaultProps = {
     29│     lazy: true,
     30│     getAccessibilityRole: () => 'button',
     31│     getAccessibilityStates: ({ focused }) => (focused ? ['selected'] : []),
     32│   };
     33│
     34│   static getDerivedStateFromProps(nextProps, prevState) {
```

#### Cannot create ResourceSavingScene element
I'm less sure about this one. As I understand it, the type for `renderScene` says it should return the Maybe React.Node, which basically means a proper Node or `null` or `undefined`. By removing the maybe type, it no longer accepts `undefined`. `null` is still allowed. I don't know if this is a unwanted. But Flow doesn't complain any longer!

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-navigation-tabs/src/navigators/createBottomTabNavigator.js:136:18

Cannot create ResourceSavingScene element because in property children:
 • Either null or undefined [1] is incompatible with null [2].
 • Or property @@iterator is missing in null or undefined [1] but exists in $Iterable [3].

     node_modules/react-navigation-tabs/src/navigators/createBottomTabNavigator.js
     128│             const isFocused = navigation.state.index === index;
     129│
     130│             return (
     131│               <ResourceSavingScene
     132│                 key={route.key}
     133│                 style={StyleSheet.absoluteFill}
     134│                 isVisible={isFocused}
     135│               >
     136│                 {renderScene({ route })}
     137│               </ResourceSavingScene>
     138│             );
     139│           })}
     140│         </ScreenContainer>

     /private/tmp/flow/flowlib_18448cb5/react.js
 [2]  14│   | null
        :
 [3]  20│   | Iterable<?React$Node>;

     node_modules/react-navigation-tabs/src/utils/createTabNavigator.js
 [1]  22│   renderScene: (props: { route: any }) => ?React.Node,
```

### Test plan
I have done the same changes within the node_modules of my app, and my Flow v0.92 check doesnt' complain anymore.

I have also run Flow in this project, as is required per commit.