### PR TITLE
Add containerStyle option to BottomTabBar

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -34,6 +34,7 @@ export type TabBarOptions = {
   labelPosition?: LabelPosition,
   adaptive?: boolean,
   style: any,
+  containerStyle: any,
 };
 
 type Props = TabBarOptions & {
@@ -309,6 +310,7 @@ class TabBarBottom extends React.Component<Props, State> {
       safeAreaInset,
       style,
       tabStyle,
+      containerStyle,
     } = this.props;
 
     const { routes } = navigation.state;
@@ -342,6 +344,7 @@ class TabBarBottom extends React.Component<Props, State> {
                 position: this.state.keyboard ? 'absolute' : null,
               }
             : null,
+          containerStyle,
         ]}
         pointerEvents={
           keyboardHidesTabBar && this.state.keyboard ? 'none' : 'auto'


### PR DESCRIPTION
This is needed to fix a regression caused by https://github.com/react-navigation/tabs/commit/2a1d7538d65e79b90c572cf078d0534e1cacc13d
That PR added a new view, but no way to control that view, which caused
a number of problems, most acutely the inability to use absolute position on Android

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Fix this issue: https://github.com/react-navigation/react-navigation/issues/5994

### Test plan
Add `containerStyle: { position: 'absolute', zIndex: 1 }` to `tabBarOptions` and see if it's clickable on Android
