### PR TITLE
feat: add sideTabs option

### DIFF
--- a/src/navigators/createBottomTabNavigator.tsx
+++ b/src/navigators/createBottomTabNavigator.tsx
@@ -134,12 +134,14 @@ class TabNavigationView extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const { navigation, renderScene, lazy } = this.props;
+    const { navigation, renderScene, lazy, tabBarOptions } = this.props;
     const { routes } = navigation.state;
     const { loaded } = this.state;
+    // @ts-ignore
+    const { sideTabs } = tabBarOptions;
 
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, sideTabs && styles.sideTabs]}>
         <ScreenContainer style={styles.pages}>
           {routes.map((route, index) => {
             if (lazy && !loaded.includes(index)) {
@@ -170,6 +172,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     overflow: 'hidden',
+  },
+  sideTabs: {
+    flexDirection: 'row-reverse',
   },
   pages: {
     flex: 1,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -48,6 +48,7 @@ export type BottomTabBarOptions = {
   showLabel?: boolean;
   showIcon?: boolean;
   labelStyle?: StyleProp<TextStyle>;
+  sideTabs?: boolean;
   tabStyle?: StyleProp<ViewStyle>;
   labelPosition?:
     | LabelPosition
@@ -108,6 +109,7 @@ export type MaterialTabBarOptions = {
   showIcon?: boolean;
   showLabel?: boolean;
   upperCaseLabel?: boolean;
+  sideTabs?: boolean;
   tabStyle?: StyleProp<ViewStyle>;
   indicatorStyle?: StyleProp<ViewStyle>;
   iconStyle?: StyleProp<ViewStyle>;

--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -197,7 +197,13 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
     route: NavigationRoute;
     focused: boolean;
   }) => {
-    const { labelStyle, showLabel, showIcon, allowFontScaling } = this.props;
+    const {
+      labelStyle,
+      showLabel,
+      showIcon,
+      allowFontScaling,
+      sideTabs,
+    } = this.props;
 
     if (showLabel === false) {
       return null;
@@ -208,6 +214,13 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
     const label = this.props.getLabelText({ route });
     const tintColor = focused ? activeTintColor : inactiveTintColor;
     const horizontal = this._shouldUseHorizontalLabels();
+    const { height } = this.state.layout;
+    const { routes } = this.props.navigation.state;
+
+    const sideStyles = {
+      height: height / (routes.length * 2) || 72,
+      flex: null,
+    };
 
     if (typeof label === 'string') {
       return (
@@ -218,6 +231,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
             { color: tintColor },
             showIcon && horizontal ? styles.labelBeside : styles.labelBeneath,
             labelStyle,
+            sideTabs && sideStyles,
           ]}
           allowFontScaling={allowFontScaling}
         >


### PR DESCRIPTION
### Motivation

It would be nice to have the ability to position the tab bar across on the side of the UI for larger devices/tablets/landscape.

### Test plan

In `tabBarOptions` config add `sideTabs` property and pass in true.
Currently only supports position on the left hand side. Right hand support could be a future improvement upon request etc.

![Screenshot_1568415034](https://user-images.githubusercontent.com/8095978/64899082-ad546980-d657-11e9-8087-3e5685c2bcb4.png)