### PR TITLE
fix #171

### DIFF
--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -260,6 +260,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
     return (
       <CrossFadeIcon
         route={route}
+        focused={focused}
         horizontal={horizontal}
         activeOpacity={activeOpacity}
         inactiveOpacity={inactiveOpacity}

--- a/src/views/CrossFadeIcon.tsx
+++ b/src/views/CrossFadeIcon.tsx
@@ -30,28 +30,29 @@ export default class TabBarIcon extends React.Component<Props> {
       renderIcon,
       horizontal,
       style,
+      focused,
     } = this.props;
 
     // We render the icon twice at the same position on top of each other:
     // active and inactive one, so we can fade between them.
     return (
       <View style={style}>
-        <Animated.View style={[styles.icon, { opacity: activeOpacity }]}>
+        <Animated.View style={[styles.icon]}>
           {renderIcon({
             route,
-            focused: true,
+            focused: focused,
             horizontal,
-            tintColor: activeTintColor,
+            tintColor: focused ? activeTintColor : inactiveTintColor,
           })}
         </Animated.View>
-        <Animated.View style={[styles.icon, { opacity: inactiveOpacity }]}>
+        {/* <Animated.View style={[styles.icon, { opacity: inactiveOpacity }]}>
           {renderIcon({
             route,
             focused: false,
             horizontal,
             tintColor: inactiveTintColor,
           })}
-        </Animated.View>
+        </Animated.View> */}
       </View>
     );
   }


### PR DESCRIPTION
fix the [https://github.com/react-navigation/tabs/issues/171](url)
The focused parameter of the tabBarIcon property is now displayed properly
