### PR TITLE
fix: fix layout when starting in landscape

### DIFF
--- a/src/utils/withDimensions.tsx
+++ b/src/utils/withDimensions.tsx
@@ -18,15 +18,20 @@ export const isOrientationLandscape = ({ width, height }: DimensionsType) =>
 export default function withDimensions<Props extends InjectedProps>(
   WrappedComponent: React.ComponentType<Props>
 ): React.ComponentType<Pick<Props, Exclude<keyof Props, keyof InjectedProps>>> {
-  const { width, height } = Dimensions.get('window');
-
   class EnhancedComponent extends React.Component {
     static displayName = `withDimensions(${WrappedComponent.displayName})`;
 
-    state = {
-      dimensions: { width, height },
-      isLandscape: isOrientationLandscape({ width, height }),
-    };
+    state = {};
+
+    constructor(props: Props) {
+      super(props);
+
+      const { width, height } = Dimensions.get('window');
+      this.state = {
+        dimensions: { width, height },
+        isLandscape: isOrientationLandscape({ width, height })
+      };
+    }
 
     componentDidMount() {
       Dimensions.addEventListener('change', this.handleOrientationChange);
@@ -37,8 +42,11 @@ export default function withDimensions<Props extends InjectedProps>(
     }
 
     handleOrientationChange = ({ window }: { window: ScaledSize }) => {
-      const isLandscape = isOrientationLandscape(window);
-      this.setState({ isLandscape });
+      const { width, height } = window;
+      this.setState({
+        dimensions: { width, height },
+        isLandscape: isOrientationLandscape({ width, height })
+      });
     };
 
     render() {

--- a/src/utils/withDimensions.tsx
+++ b/src/utils/withDimensions.tsx
@@ -21,15 +21,13 @@ export default function withDimensions<Props extends InjectedProps>(
   class EnhancedComponent extends React.Component {
     static displayName = `withDimensions(${WrappedComponent.displayName})`;
 
-    state = {};
-
     constructor(props: Props) {
       super(props);
 
       const { width, height } = Dimensions.get('window');
       this.state = {
         dimensions: { width, height },
-        isLandscape: isOrientationLandscape({ width, height })
+        isLandscape: isOrientationLandscape({ width, height }),
       };
     }
 
@@ -45,7 +43,7 @@ export default function withDimensions<Props extends InjectedProps>(
       const { width, height } = window;
       this.setState({
         dimensions: { width, height },
-        isLandscape: isOrientationLandscape({ width, height })
+        isLandscape: isOrientationLandscape({ width, height }),
       });
     };
 


### PR DESCRIPTION
### Motivation

When starting the app in landscape mode and then switch to portrait the calculation of the tab bar dimensions are incorrect

### Test plan

1. Start the example app in landscape
2. Turn the phone back to portrait
3. Enter the "Bottom tabs" example

### Result
![IMG_5041](https://user-images.githubusercontent.com/474066/66696530-0e11a900-eccd-11e9-8857-134d4d03c4dd.jpg)

### Expected
![IMG_5039](https://user-images.githubusercontent.com/474066/66696537-1a960180-eccd-11e9-859c-2dadd3effc63.jpg)




