### PR TITLE
feat: export BottomTabBarProps

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ export { default as createTabNavigator } from './utils/createTabNavigator';
  * Types
  */
 export {
+  BottomTabBarProps,
   NavigationTabState,
   NavigationTabProp,
   NavigationTabScreenProps,


### PR DESCRIPTION
### Motivation

You can't import BottomTabBarProps from
`import { BottomTabBarProps } from 'react-navigation-tabs'`

### Test plan
Try to import `BottomTabBarProps` from `react-navigation-tabs`

Fixes #187 
