### PR TITLE
update react-native-safe-area-view to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "hoist-non-react-statics": "^3.3.0",
     "react-lifecycles-compat": "^3.0.4",
+    "react-native-safe-area-context": "^0.5.0",
     "react-native-safe-area-view": "^1.0.0",
     "react-native-tab-view": "^2.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "hoist-non-react-statics": "^3.3.0",
     "react-lifecycles-compat": "^3.0.4",
-    "react-native-safe-area-view": "^0.14.6",
+    "react-native-safe-area-view": "^1.0.0",
     "react-native-tab-view": "^2.9.0"
   },
   "devDependencies": {

--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -8,7 +8,7 @@ import {
   Platform,
   LayoutChangeEvent,
 } from 'react-native';
-import { SafeAreaProvider } from "react-native-safe-area-context";
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import SafeAreaView from 'react-native-safe-area-view';
 import { ThemeColors, ThemeContext, NavigationRoute } from 'react-navigation';
 

--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -8,6 +8,7 @@ import {
   Platform,
   LayoutChangeEvent,
 } from 'react-native';
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import SafeAreaView from 'react-native-safe-area-view';
 import { ThemeColors, ThemeContext, NavigationRoute } from 'react-navigation';
 
@@ -386,85 +387,87 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
     ];
 
     return (
-      <Animated.View
-        style={[
-          styles.container,
-          keyboardHidesTabBar
-            ? {
-                // When the keyboard is shown, slide down the tab bar
-                transform: [
-                  {
-                    translateY: this.state.visible.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [this.state.layout.height, 0],
-                    }),
-                  },
-                ],
-                // Absolutely position the tab bar so that the content is below it
-                // This is needed to avoid gap at bottom when the tab bar is hidden
-                position: this.state.keyboard ? 'absolute' : null,
-              }
-            : null,
-          containerStyle,
-        ]}
-        pointerEvents={
-          keyboardHidesTabBar && this.state.keyboard ? 'none' : 'auto'
-        }
-        onLayout={this._handleLayout}
-      >
-        <SafeAreaView style={tabBarStyle} forceInset={safeAreaInset}>
-          {routes.map((route, index) => {
-            const focused = index === navigation.state.index;
-            const scene = { route, focused };
-            const accessibilityLabel = this.props.getAccessibilityLabel({
-              route,
-            });
+      <SafeAreaProvider>
+        <Animated.View
+          style={[
+            styles.container,
+            keyboardHidesTabBar
+              ? {
+                  // When the keyboard is shown, slide down the tab bar
+                  transform: [
+                    {
+                      translateY: this.state.visible.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [this.state.layout.height, 0],
+                      }),
+                    },
+                  ],
+                  // Absolutely position the tab bar so that the content is below it
+                  // This is needed to avoid gap at bottom when the tab bar is hidden
+                  position: this.state.keyboard ? 'absolute' : null,
+                }
+              : null,
+            containerStyle,
+          ]}
+          pointerEvents={
+            keyboardHidesTabBar && this.state.keyboard ? 'none' : 'auto'
+          }
+          onLayout={this._handleLayout}
+        >
+          <SafeAreaView style={tabBarStyle} forceInset={safeAreaInset}>
+            {routes.map((route, index) => {
+              const focused = index === navigation.state.index;
+              const scene = { route, focused };
+              const accessibilityLabel = this.props.getAccessibilityLabel({
+                route,
+              });
 
-            const accessibilityRole = this.props.getAccessibilityRole({
-              route,
-            });
+              const accessibilityRole = this.props.getAccessibilityRole({
+                route,
+              });
 
-            const accessibilityStates = this.props.getAccessibilityStates(
-              scene
-            );
+              const accessibilityStates = this.props.getAccessibilityStates(
+                scene
+              );
 
-            const testID = this.props.getTestID({ route });
+              const testID = this.props.getTestID({ route });
 
-            const backgroundColor = focused
-              ? activeBackgroundColor
-              : inactiveBackgroundColor;
+              const backgroundColor = focused
+                ? activeBackgroundColor
+                : inactiveBackgroundColor;
 
-            const ButtonComponent =
-              this.props.getButtonComponent({ route }) ||
-              TouchableWithoutFeedbackWrapper;
+              const ButtonComponent =
+                this.props.getButtonComponent({ route }) ||
+                TouchableWithoutFeedbackWrapper;
 
-            return (
-              <ButtonComponent
-                key={route.key}
-                route={route}
-                focused={focused}
-                onPress={() => onTabPress({ route })}
-                onLongPress={() => onTabLongPress({ route })}
-                testID={testID}
-                accessibilityLabel={accessibilityLabel}
-                accessibilityRole={accessibilityRole}
-                accessibilityStates={accessibilityStates}
-                style={[
-                  styles.tab,
-                  { backgroundColor },
-                  this._shouldUseHorizontalLabels()
-                    ? styles.tabLandscape
-                    : styles.tabPortrait,
-                  tabStyle,
-                ]}
-              >
-                {this._renderIcon(scene)}
-                {this._renderLabel(scene)}
-              </ButtonComponent>
-            );
-          })}
-        </SafeAreaView>
-      </Animated.View>
+              return (
+                <ButtonComponent
+                  key={route.key}
+                  route={route}
+                  focused={focused}
+                  onPress={() => onTabPress({ route })}
+                  onLongPress={() => onTabLongPress({ route })}
+                  testID={testID}
+                  accessibilityLabel={accessibilityLabel}
+                  accessibilityRole={accessibilityRole}
+                  accessibilityStates={accessibilityStates}
+                  style={[
+                    styles.tab,
+                    { backgroundColor },
+                    this._shouldUseHorizontalLabels()
+                      ? styles.tabLandscape
+                      : styles.tabPortrait,
+                    tabStyle,
+                  ]}
+                >
+                  {this._renderIcon(scene)}
+                  {this._renderLabel(scene)}
+                </ButtonComponent>
+              );
+            })}
+          </SafeAreaView>
+        </Animated.View>
+      </SafeAreaProvider>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7600,6 +7600,11 @@ react-native-reanimated@^1.2.0:
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.2.0.tgz#9219227a52a5dfa4d34c324596d6726ccd874293"
   integrity sha512-vkWRHrPK5qfHP/ZawlRoo38oeYe9NZaaOH/lmFxRcsKzaSK6x3H5ZPXI8lK6MfTLveqwo1QhJje3zIKXO4nQQw==
 
+react-native-safe-area-context@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.5.0.tgz#2185519ad6296dd7bd4ecc79864c02ca3a7f40b5"
+  integrity sha512-ukg9gO9jCdQIkYYwQf0/mp+67XiFSJH7BOxthoBbJq0x3f61Q/6U6E2v5MkcHO0vJg1Ul4/Pq77V+nR5eY/9fA==
+
 react-native-safe-area-view@^0.14.1:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.8.tgz#ef33c46ff8164ae77acad48c3039ec9c34873e5b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7607,10 +7607,10 @@ react-native-safe-area-view@^0.14.1:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-react-native-safe-area-view@^0.14.6:
-  version "0.14.6"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.6.tgz#9a9d37d9f8f3887d60c4076eae7b5d2319539446"
-  integrity sha512-dbzuvaeHFV1VBpyMaC0gtJ2BqFt6ls/405A0t78YN1sXiTrVr3ki86Ysct8mzifWqLdvWzcWagE5wfMtdxnqoA==
+react-native-safe-area-view@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-1.0.0.tgz#17be33aeb30702e07bb846378f4c9561e2dd6684"
+  integrity sha512-cJOBfM6t7HL3NQf3QTVKO6BU7esCCMbKJjpNy9L2nT724UzZ2y6E3ol/3QWsw7ySegWlF857+RIkRLsnpltFVg==
   dependencies:
     hoist-non-react-statics "^2.3.1"
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
I am using the latest version `1.0` of `react-native-safe-area-view` in one of our projects. I noticed different layout behaviours in version `1.0` and the version used by react-navigation/tabs `^0.14.6`. It seems that the newer version has about 3 pixels less bottom space for iPhones with notches in landscape.  

Speaking about visual appearance, i think the latest version looks better but what actually matters for our project is consistency between our bottom insets and the insets used for the tab navigator. To guarantee this consistency i updated `react-native-safe-area-view` in react-navigation/tabs which worked for me out of the box.

![IMG_0267](https://user-images.githubusercontent.com/5617793/67220247-b9d39b00-f429-11e9-876d-81d1ad111c92.jpg)


This change might also introduce an additional step for the initial setup, because it requires setting up a `SafeAreaProvider` via react-native-safe-area-context. [(more info)](https://github.com/react-native-community/react-native-safe-area-view). If you can point me where to change it in the docs i'm thrilled to help.

Thanks in advance
