### PR TITLE
feat: expose tab bar height

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { registerRootComponent } from 'expo';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import {
   Assets as StackAssets,
@@ -143,5 +142,4 @@ const styles = {
   },
 };
 
-// @ts-ignore
-registerRootComponent(App);
+export default App;

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -17,6 +17,7 @@ import { Asset } from 'expo-asset';
 
 import BottomTabs from './src/BottomTabs';
 import MaterialTopTabs from './src/MaterialTopTabs';
+import TransparentTabBar from './src/TransparentTabBar';
 
 // Load the back button etc
 Asset.loadAsync(StackAssets);
@@ -40,6 +41,13 @@ const Home = (props: NavigationStackScreenProps) => {
       >
         <Themed.Text>Material top tabs</Themed.Text>
       </TouchableOpacity>
+      <TouchableOpacity
+        activeOpacity={0.8}
+        style={theme === 'dark' ? styles.itemDark : styles.itemLight}
+        onPress={() => props.navigation.push('TransparentTabBar')}
+      >
+        <Themed.Text>Transparent tab bar</Themed.Text>
+      </TouchableOpacity>
       <Themed.StatusBar />
     </View>
   );
@@ -57,6 +65,10 @@ const List = createStackNavigator({
   MaterialTopTabs: {
     screen: MaterialTopTabs,
     navigationOptions: { title: 'Material top tabs' },
+  },
+  TransparentTabBar: {
+    screen: TransparentTabBar,
+    navigationOptions: { title: 'Transparent tab bar' },
   },
 });
 

--- a/example/src/BottomTabs.tsx
+++ b/example/src/BottomTabs.tsx
@@ -83,5 +83,5 @@ export default createBottomTabNavigator(
         bottom: 0,
       },
     },
-  },
+  }
 );

--- a/example/src/BottomTabs.tsx
+++ b/example/src/BottomTabs.tsx
@@ -76,12 +76,5 @@ export default createBottomTabNavigator(
   },
   {
     initialRouteName: 'AlbumsScreen',
-    tabBarOptions: {
-      style: {
-        backgroundColor: 'rgba(245, 245, 245, 0.8)',
-        position: 'absolute',
-        bottom: 0,
-      },
-    },
   }
 );

--- a/example/src/BottomTabs.tsx
+++ b/example/src/BottomTabs.tsx
@@ -76,5 +76,12 @@ export default createBottomTabNavigator(
   },
   {
     initialRouteName: 'AlbumsScreen',
-  }
+    tabBarOptions: {
+      style: {
+        backgroundColor: 'rgba(245, 245, 245, 0.8)',
+        position: 'absolute',
+        bottom: 0,
+      },
+    },
+  },
 );

--- a/example/src/Shared/Albums.tsx
+++ b/example/src/Shared/Albums.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Image, Dimensions, ScrollView, StyleSheet, View } from 'react-native';
+import { Image, Dimensions, ScrollView, StyleSheet } from 'react-native';
 import { TabBarHeightContext } from 'react-navigation-tabs';
 
 const COVERS = [

--- a/example/src/Shared/Albums.tsx
+++ b/example/src/Shared/Albums.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Image, Dimensions, ScrollView, StyleSheet } from 'react-native';
-import { TabBarHeightContext } from 'react-navigation-tabs';
 
-const COVERS = [
+export const COVERS = [
   require('../../assets/album-art-1.jpg'),
   require('../../assets/album-art-2.jpg'),
   require('../../assets/album-art-3.jpg'),
@@ -16,29 +15,22 @@ const COVERS = [
 export default class Albums extends React.Component {
   render() {
     return (
-      <TabBarHeightContext.Consumer>
-        {height => (
-          <ScrollView
-            style={styles.container}
-            contentContainerStyle={[
-              styles.content,
-              { padding: 20, paddingBottom: height + 20 },
-            ]}
-          >
-            {COVERS.map((source, i) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <Image key={i} source={source} style={styles.cover} />
-            ))}
-          </ScrollView>
-        )}
-      </TabBarHeightContext.Consumer>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.content}
+      >
+        {COVERS.map((source, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Image key={i} source={source} style={styles.cover} />
+        ))}
+      </ScrollView>
     );
   }
 }
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: 'whitesmoke',
+    backgroundColor: '#343C46',
   },
   content: {
     flexDirection: 'row',

--- a/example/src/Shared/Albums.tsx
+++ b/example/src/Shared/Albums.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Image, Dimensions, ScrollView, StyleSheet } from 'react-native';
+import { Image, Dimensions, ScrollView, StyleSheet, View } from 'react-native';
+import { TabBarHeightContext } from 'react-navigation-tabs';
 
 const COVERS = [
   require('../../assets/album-art-1.jpg'),
@@ -15,22 +16,29 @@ const COVERS = [
 export default class Albums extends React.Component {
   render() {
     return (
-      <ScrollView
-        style={styles.container}
-        contentContainerStyle={styles.content}
-      >
-        {COVERS.map((source, i) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <Image key={i} source={source} style={styles.cover} />
-        ))}
-      </ScrollView>
+      <TabBarHeightContext.Consumer>
+        {height => (
+          <ScrollView
+            style={styles.container}
+            contentContainerStyle={[
+              styles.content,
+              { padding: 20, paddingBottom: height + 20 },
+            ]}
+          >
+            {COVERS.map((source, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Image key={i} source={source} style={styles.cover} />
+            ))}
+          </ScrollView>
+        )}
+      </TabBarHeightContext.Consumer>
     );
   }
 }
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#343C46',
+    backgroundColor: 'whitesmoke',
   },
   content: {
     flexDirection: 'row',

--- a/example/src/TransparentTabBar.tsx
+++ b/example/src/TransparentTabBar.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import {
+  createBottomTabNavigator,
+  TabBarHeightContext,
+} from 'react-navigation-tabs';
+import { MaterialIcons } from '@expo/vector-icons';
+
+// @ts-ignore
+import TouchableBounce from 'react-native/Libraries/Components/Touchable/TouchableBounce';
+import { ScrollView, Image } from 'react-native';
+import { COVERS } from './Shared/Albums';
+
+const tabBarIcon = (name: string) => ({
+  tintColor,
+  horizontal,
+}: {
+  tintColor: string;
+  horizontal: boolean;
+}) => (
+  <MaterialIcons name={name} color={tintColor} size={horizontal ? 17 : 24} />
+);
+
+const AltAlbumsScreen = () => (
+  <TabBarHeightContext.Consumer>
+    {height => (
+      <ScrollView
+        contentContainerStyle={{ padding: 20, paddingBottom: height + 20 }}
+        style={{ backgroundColor: 'whitesmoke' }}
+      >
+        {COVERS.map((source, i) => (
+          <Image
+            // eslint-disable-next-line react/no-array-index-key
+            key={`photo_${i}`}
+            source={source}
+            style={{
+              width: '100%',
+              height: 230,
+              marginTop: i !== 0 ? 20 : 0,
+              borderRadius: 10,
+            }}
+          />
+        ))}
+      </ScrollView>
+    )}
+  </TabBarHeightContext.Consumer>
+);
+
+AltAlbumsScreen.navigationOptions = {
+  tabBarLabel: 'Albums',
+  tabBarIcon: tabBarIcon('photo-album'),
+  tabBarButtonComponent: TouchableBounce,
+};
+
+export default createBottomTabNavigator(
+  { AltAlbumsScreen },
+  {
+    initialRouteName: 'AltAlbumsScreen',
+    tabBarOptions: {
+      style: {
+        backgroundColor: 'rgba(220, 220, 220, 0.7)',
+        position: 'absolute',
+        bottom: 0,
+      },
+    },
+  }
+);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,7 @@ export { default as MaterialTopTabBar } from './views/MaterialTopTabBar';
  * Utils
  */
 export { default as createTabNavigator } from './utils/createTabNavigator';
+export { default as TabBarHeightContext } from './utils/TabBarHeightContext';
 
 /**
  * Types

--- a/src/navigators/createBottomTabNavigator.tsx
+++ b/src/navigators/createBottomTabNavigator.tsx
@@ -175,8 +175,8 @@ class TabNavigationView extends React.PureComponent<Props, State> {
               );
             })}
           </ScreenContainer>
-          {this._renderTabBar()}
         </TabBarHeightContext.Provider>
+        {this._renderTabBar()}
       </View>
     );
   }

--- a/src/navigators/createBottomTabNavigator.tsx
+++ b/src/navigators/createBottomTabNavigator.tsx
@@ -13,6 +13,7 @@ import { ScreenContainer } from 'react-native-screens';
 import createTabNavigator, {
   NavigationViewProps,
 } from '../utils/createTabNavigator';
+import TabBarHeightContext from '../utils/TabBarHeightContext';
 import BottomTabBar from '../views/BottomTabBar';
 import ResourceSavingScene from '../views/ResourceSavingScene';
 import {
@@ -44,6 +45,7 @@ type Props = NavigationViewProps &
 
 type State = {
   loaded: number[];
+  tabBarHeight: number;
 };
 
 class TabNavigationView extends React.PureComponent<Props, State> {
@@ -70,6 +72,7 @@ class TabNavigationView extends React.PureComponent<Props, State> {
 
   state = {
     loaded: [this.props.navigation.state.index],
+    tabBarHeight: 0,
   };
 
   _getButtonComponent = ({ route }: { route: NavigationRoute }) => {
@@ -82,6 +85,12 @@ class TabNavigationView extends React.PureComponent<Props, State> {
     }
 
     return undefined;
+  };
+
+  _onTabBarHeightChange = (tabBarHeight: number) => {
+    if (this.state.tabBarHeight !== tabBarHeight) {
+      this.setState({ tabBarHeight });
+    }
   };
 
   _renderTabBar = () => {
@@ -118,6 +127,7 @@ class TabNavigationView extends React.PureComponent<Props, State> {
         screenProps={screenProps}
         onTabPress={onTabPress}
         onTabLongPress={onTabLongPress}
+        onHeightChange={this._onTabBarHeightChange}
         getLabelText={getLabelText}
         getButtonComponent={this._getButtonComponent}
         getAccessibilityLabel={getAccessibilityLabel}
@@ -144,27 +154,29 @@ class TabNavigationView extends React.PureComponent<Props, State> {
 
     return (
       <View style={styles.container}>
-        <ScreenContainer style={styles.pages}>
-          {routes.map((route, index) => {
-            if (lazy && !loaded.includes(index)) {
-              // Don't render a screen if we've never navigated to it
-              return null;
-            }
+        <TabBarHeightContext.Provider value={this.state.tabBarHeight}>
+          <ScreenContainer style={styles.pages}>
+            {routes.map((route, index) => {
+              if (lazy && !loaded.includes(index)) {
+                // Don't render a screen if we've never navigated to it
+                return null;
+              }
 
-            const isFocused = navigation.state.index === index;
+              const isFocused = navigation.state.index === index;
 
-            return (
-              <ResourceSavingScene
-                key={route.key}
-                style={StyleSheet.absoluteFill}
-                isVisible={isFocused}
-              >
-                {renderScene({ route })}
-              </ResourceSavingScene>
-            );
-          })}
-        </ScreenContainer>
-        {this._renderTabBar()}
+              return (
+                <ResourceSavingScene
+                  key={route.key}
+                  style={StyleSheet.absoluteFill}
+                  isVisible={isFocused}
+                >
+                  {renderScene({ route })}
+                </ResourceSavingScene>
+              );
+            })}
+          </ScreenContainer>
+          {this._renderTabBar()}
+        </TabBarHeightContext.Provider>
       </View>
     );
   }
@@ -181,5 +193,5 @@ const styles = StyleSheet.create({
 });
 
 export default createTabNavigator<Config, NavigationBottomTabOptions, Props>(
-  TabNavigationView
+  TabNavigationView,
 );

--- a/src/navigators/createBottomTabNavigator.tsx
+++ b/src/navigators/createBottomTabNavigator.tsx
@@ -193,5 +193,5 @@ const styles = StyleSheet.create({
 });
 
 export default createTabNavigator<Config, NavigationBottomTabOptions, Props>(
-  TabNavigationView,
+  TabNavigationView
 );

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -114,6 +114,7 @@ export type BottomTabBarProps = BottomTabBarOptions & {
   navigation: NavigationTabProp;
   onTabPress: (props: { route: NavigationRoute }) => void;
   onTabLongPress: (props: { route: NavigationRoute }) => void;
+  onHeightChange?: (height: number) => void;
   getAccessibilityLabel: (props: {
     route: NavigationRoute;
   }) => string | undefined;

--- a/src/utils/TabBarHeightContext.tsx
+++ b/src/utils/TabBarHeightContext.tsx
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export default React.createContext<number>(0);

--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -142,7 +142,7 @@ class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
   context: 'light' | 'dark';
 
   _getKeyboardAnimationConfigByType = (
-    type: keyof KeyboardHidesTabBarAnimationConfig,
+    type: keyof KeyboardHidesTabBarAnimationConfig
   ): KeyboardAnimationConfig => {
     const { keyboardHidesTabBarAnimationConfig } = this.props;
     const defaultKeyboardAnimationConfig =
@@ -173,7 +173,7 @@ class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
   _handleKeyboardShow = () => {
     this.setState({ keyboard: true }, () => {
       const { animation, config } = this._getKeyboardAnimationConfigByType(
-        'show',
+        'show'
       );
       Animated[animation](this.state.visible, {
         toValue: 0,
@@ -184,7 +184,7 @@ class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
 
   _handleKeyboardHide = () => {
     const { animation, config } = this._getKeyboardAnimationConfigByType(
-      'hide',
+      'hide'
     );
     Animated[animation](this.state.visible, {
       toValue: 1,
@@ -213,7 +213,7 @@ class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
         if (this.props.onHeightChange) {
           this.props.onHeightChange(this.state.layout.height);
         }
-      },
+      }
     );
   };
 
@@ -493,7 +493,7 @@ class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
             });
 
             const accessibilityStates = this.props.getAccessibilityStates(
-              scene,
+              scene
             );
 
             const testID = this.props.getTestID({ route });

--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -20,6 +20,10 @@ import {
   KeyboardAnimationConfig,
 } from '../types';
 
+type Props = {
+  onHeightChange?: (height: number) => void;
+};
+
 type State = {
   layout: { height: number; width: number };
   keyboard: boolean;
@@ -82,7 +86,7 @@ class TouchableWithoutFeedbackWrapper extends React.Component<
   }
 }
 
-class TabBarBottom extends React.Component<BottomTabBarProps, State> {
+class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
   static defaultProps = {
     keyboardHidesTabBar: true,
     keyboardHidesTabBarAnimationConfig: DEFAULT_KEYBOARD_ANIMATION_CONFIG,
@@ -138,7 +142,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
   context: 'light' | 'dark';
 
   _getKeyboardAnimationConfigByType = (
-    type: keyof KeyboardHidesTabBarAnimationConfig
+    type: keyof KeyboardHidesTabBarAnimationConfig,
   ): KeyboardAnimationConfig => {
     const { keyboardHidesTabBarAnimationConfig } = this.props;
     const defaultKeyboardAnimationConfig =
@@ -169,7 +173,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
   _handleKeyboardShow = () => {
     this.setState({ keyboard: true }, () => {
       const { animation, config } = this._getKeyboardAnimationConfigByType(
-        'show'
+        'show',
       );
       Animated[animation](this.state.visible, {
         toValue: 0,
@@ -180,7 +184,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
 
   _handleKeyboardHide = () => {
     const { animation, config } = this._getKeyboardAnimationConfigByType(
-      'hide'
+      'hide',
     );
     Animated[animation](this.state.visible, {
       toValue: 1,
@@ -198,12 +202,19 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
       return;
     }
 
-    this.setState({
-      layout: {
-        height,
-        width,
+    this.setState(
+      {
+        layout: {
+          height,
+          width,
+        },
       },
-    });
+      () => {
+        if (this.props.onHeightChange) {
+          this.props.onHeightChange(this.state.layout.height);
+        }
+      },
+    );
   };
 
   _getActiveTintColor = () => {
@@ -482,7 +493,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
             });
 
             const accessibilityStates = this.props.getAccessibilityStates(
-              scene
+              scene,
             );
 
             const testID = this.props.getTestID({ route });

--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -20,10 +20,6 @@ import {
   KeyboardAnimationConfig,
 } from '../types';
 
-type Props = {
-  onHeightChange?: (height: number) => void;
-};
-
 type State = {
   layout: { height: number; width: number };
   keyboard: boolean;
@@ -86,7 +82,7 @@ class TouchableWithoutFeedbackWrapper extends React.Component<
   }
 }
 
-class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
+class TabBarBottom extends React.Component<BottomTabBarProps, State> {
   static defaultProps = {
     keyboardHidesTabBar: true,
     keyboardHidesTabBarAnimationConfig: DEFAULT_KEYBOARD_ANIMATION_CONFIG,
@@ -202,19 +198,16 @@ class TabBarBottom extends React.Component<Props & BottomTabBarProps, State> {
       return;
     }
 
-    this.setState(
-      {
-        layout: {
-          height,
-          width,
-        },
+    if (this.props.onHeightChange) {
+      this.props.onHeightChange(height);
+    }
+
+    this.setState({
+      layout: {
+        height,
+        width,
       },
-      () => {
-        if (this.props.onHeightChange) {
-          this.props.onHeightChange(this.state.layout.height);
-        }
-      }
-    );
+    });
   };
 
   _getActiveTintColor = () => {


### PR DESCRIPTION
### Motivation

Some user(s) mentioned their use case of wanting to implement a transparent tab bar. This is do-able by absolutely positioning the tab bar in `tabBarOptions.style` - However, when using this approach, it'd be ideal to have a way to access the tab bar height (e.g. to add padding if needed). This PR exposes the tab bar height as part of the public API via context.

Closes https://github.com/react-navigation/tabs/issues/184
Also somewhat related to https://github.com/react-navigation/tabs/issues/46

### Test plan

A new example of a context aware transparent (absolutely positioned) tab bar was added to the `example` directory. 

<details>
<summary>GIF of example</summary>

![ssttb](https://user-images.githubusercontent.com/20142959/67979957-c14a2f80-fbf3-11e9-8062-220100e12404.gif)

</details>
