### PR TITLE
fix: make it possible to run example app

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { registerRootComponent } from 'expo';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import {
   Assets as StackAssets,
@@ -130,4 +131,5 @@ const styles = {
   },
 };
 
-export default App;
+// @ts-ignore
+registerRootComponent(App);

--- a/example/src/Shared/Chat.tsx
+++ b/example/src/Shared/Chat.tsx
@@ -8,7 +8,7 @@ const MESSAGES = [
   'make me a sandwich',
 ];
 
-export default class Albums extends React.Component {
+export default class Chat extends React.Component {
   render() {
     return (
       <View style={styles.container}>

--- a/example/src/Shared/Contacts.tsx
+++ b/example/src/Shared/Contacts.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, StyleSheet, FlatList } from 'react-native';
+import { View, Text, StyleSheet, FlatList, TextInput } from 'react-native';
 
 type Item = { name: string; number: number };
 
@@ -85,12 +85,18 @@ export default class Contacts extends React.Component {
 
   render() {
     return (
-      <FlatList
-        data={CONTACTS}
-        keyExtractor={(_, i) => String(i)}
-        renderItem={this._renderItem}
-        ItemSeparatorComponent={this._ItemSeparator}
-      />
+      <>
+        <TextInput
+          style={styles.textInput}
+          value="readonly textinput to see how tab bar behaves w/ keyboard"
+        />
+        <FlatList
+          data={CONTACTS}
+          keyExtractor={(_, i) => String(i)}
+          renderItem={this._renderItem}
+          ItemSeparatorComponent={this._ItemSeparator}
+        />
+      </>
     );
   }
 }
@@ -129,5 +135,8 @@ const styles = StyleSheet.create({
   separator: {
     height: StyleSheet.hairlineWidth,
     backgroundColor: 'rgba(0, 0, 0, .08)',
+  },
+  textInput: {
+    height: 50,
   },
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

When following the readme instructions, example app fails with `module appregistry is not a registered callable module` I noticed there was a recent commit that broke this for me https://github.com/react-navigation/tabs/commit/8b9aa68b65a29b284cabd9a1fd6e71183e88eea8

I also added a TextInput that I wanted to use to test behavior of tab bar when keyboard it up, but noticed that the content stays hidden behind the keyboard, is this an expo thing? (vanilla RN moves content above keyboard). Thanks!

### Test plan

following the readme, example app works
