### PR TITLE
fix: white block when keyboard is open

### DIFF
--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -446,6 +446,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
       <Animated.View
         style={[
           styles.container,
+          containerStyle,
           keyboardHidesTabBar
             ? {
                 // When the keyboard is shown, slide down the tab bar
@@ -459,10 +460,9 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
                 ],
                 // Absolutely position the tab bar so that the content is below it
                 // This is needed to avoid gap at bottom when the tab bar is hidden
-                position: this.state.keyboard ? 'absolute' : null,
+                position: this.state.keyboard ? 'absolute' : undefined,
               }
             : null,
-          containerStyle,
         ]}
         pointerEvents={
           keyboardHidesTabBar && this.state.keyboard ? 'none' : 'auto'


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

this fixes #206

### Test plan

tested locally, please see the videos here [before-and-after.zip](https://github.com/react-navigation/tabs/files/3876932/before-and-after.zip)


related https://github.com/react-navigation/tabs/commit/c8e1cd24bd92bc51ed916d2e07feae39be3b3757#diff-df8db9f0a4883d10ede795953bd329bb