### PR TITLE
add showLabelOnFocus flag on tabBarOptions

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -87,6 +87,7 @@ export type BottomTabBarOptions = {
   inactiveBackgroundColor?: ThemedColor;
   allowFontScaling?: boolean;
   showLabel?: boolean;
+  showLabelOnFocus?: boolean;
   showIcon?: boolean;
   labelStyle?: StyleProp<TextStyle>;
   tabStyle?: StyleProp<ViewStyle>;
@@ -160,6 +161,7 @@ export type MaterialTabBarOptions = {
   scrollEnabled?: boolean;
   showIcon?: boolean;
   showLabel?: boolean;
+  showLabelOnFocus?: boolean;
   upperCaseLabel?: boolean;
   tabStyle?: StyleProp<ViewStyle>;
   indicatorStyle?: StyleProp<ViewStyle>;

--- a/src/views/BottomTabBar.tsx
+++ b/src/views/BottomTabBar.tsx
@@ -97,6 +97,7 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
     activeBackgroundColor: 'transparent',
     inactiveBackgroundColor: 'transparent',
     showLabel: true,
+    showLabelOnFocus: false,
     showIcon: true,
     allowFontScaling: true,
     adaptive: isIOS11,
@@ -257,7 +258,17 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
     route: NavigationRoute;
     focused: boolean;
   }) => {
-    const { labelStyle, showLabel, showIcon, allowFontScaling } = this.props;
+    const {
+      labelStyle,
+      showLabel,
+      showLabelOnFocus,
+      showIcon,
+      allowFontScaling,
+    } = this.props;
+
+    if (showLabelOnFocus === true && focused === false) {
+      return null;
+    }
 
     if (showLabel === false) {
       return null;

--- a/src/views/MaterialTopTabBar.tsx
+++ b/src/views/MaterialTopTabBar.tsx
@@ -14,6 +14,7 @@ export default class TabBarTop extends React.PureComponent<
     activeTintColor: 'rgba(255, 255, 255, 1)',
     inactiveTintColor: 'rgba(255, 255, 255, 0.7)',
     showIcon: false,
+    showLabelOnFocus: false,
     showLabel: true,
     upperCaseLabel: true,
     allowFontScaling: true,
@@ -22,10 +23,15 @@ export default class TabBarTop extends React.PureComponent<
   _renderLabel = ({ route, focused, color }: Scene) => {
     const {
       showLabel,
+      showLabelOnFocus,
       upperCaseLabel,
       labelStyle,
       allowFontScaling,
     } = this.props;
+
+    if (showLabelOnFocus === true && focused === false) {
+      return null;
+    }
 
     if (showLabel === false) {
       return null;


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR adds `showLabelOnFocus` to tabBarOptions. This makes possible to easily show the tab's label **only** on **focused** tabs.


![Screenshot_20191214_065405](https://user-images.githubusercontent.com/28146931/70847053-8e27cc80-1e3e-11ea-80c3-decac00e8029.png)